### PR TITLE
Chore: set default vars in script

### DIFF
--- a/.env
+++ b/.env
@@ -1,38 +1,7 @@
-## Parameters
-# Hostname. Used as <DNS_NAME>.<LOCATION>.cloudapp.azure.com
-export DNS_NAME="bvt-juice"
-# Region in which to deploy the services
-export LOCATION="norway-east"
-# Name of the resource group to use/create. Will be created/deleted if 'MANAGE_RG' is 1
-export RESOURCE_GROUP=MultiJuicer
-# Name to use for the cluster
-export CLUSTER_NAME=juicy-k8s
-# Name to use for the container registry
-export REGISTRY_NAME=bvtmultijuicer
-# Number of nodes for the cluster
-export NODE_COUNT=2
-# Number of replicas for multi-juicer
-export BALANCER_REPLICAS=3
-# Max. number of instances of JuiceShop
-export MAX_INSTANCES=5
 # Key used to generate the challenge flags. Should be rotated between CTF-events
 export CTF_KEY="Sjc1tiJ@xf+Z8.Bpwy-EQ%w:Ni42bJf4"
 # Secret for the cookie parser. Rotate to invalidate all active sessions.
 export COOKIE_SECRET="X4piWV9rXtCzZeAlEermJNCb"
-# Username of the metrics-user
-export METRICS_USER="prometheus-scraper"
-# Password of the metrics-user
-export METRICS_PASS=""
-# Password of the grafana user
-export GRAFANA_PASS=""
-# Password for the CTFd Redis instance
-export CTFD_REDIS_PASS=""
-# Root password for the CTFd MySQL instance
-export CTFD_MYSQL_ROOT_PASS=""
-# Password for the CTFd MySQL user
-export CTFD_MYSQL_PASS=""
-# Password for the CTFd MySQL instance
-export CTFD_MYSQL_REPL_PASS=""
 # Secret for the CTFd instance
 export CTFD_SECRET_KEY="5j6wBeLsVzLQmZPgHtuNUCXp"
 # The subscription ID
@@ -44,7 +13,6 @@ export SERVICE_PRINCIPAL_NAME="nord-juice-shop"
 # Name of the admin AAD group
 export ADMIN_AAD_GROUP="nord-juicy-admins"
 
-## Toggles
 # Whether to create/delete the resource group. Defaults to false
 export MANAGE_RG=0
 # Whether to create/delete a container registry. Defaults to false, unless COMMAND is 'new' or 'wipe'


### PR DESCRIPTION
Instead of having all env vars defined in `.env`, we define them with defaults in the script that uses them. This is done both to ensure defaults, as well as to avoid having to provide all the env vars in the .env file every time.