### PR TITLE
chore: pin versions for multijuicer and ctfd, upgrade juice shop

### DIFF
--- a/juicer.yaml
+++ b/juicer.yaml
@@ -35,7 +35,7 @@ balancer:
 juiceShop:
   # -- Specifies how many JuiceShop instances MultiJuicer should start at max. Set to -1 to remove the max Juice Shop instance cap
   maxInstances: 5
-  tag: v15.1.0
+  tag: v15.2.1
   # -- Change the key when hosting a CTF event. This key gets used to generate the challenge flags. See: https://pwning.owasp-juice.shop/part1/ctf.html#overriding-the-ctfkey
   ctfKey: "48yG26ZxFpsfAroewUf@jj$ML#R9&FMx"
   # -- Specify a custom Juice Shop config.yaml. See the JuiceShop Config Docs for more detail: https://pwning.owasp-juice.shop/part1/customization.html#yaml-configuration-file

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -46,6 +46,11 @@ MANAGE_CLUSTER=${MANAGE_CLUSTER:-0}
 MANAGE_MONITORING=${MANAGE_MONITORING:-0}
 # Whether to configure the CTFd deployment. Defaults to true
 MANAGE_CTFD=${MANAGE_CTFD:-1}
+# MultiJuicer helm chart version, https://github.com/juice-shop/multi-juicer/releases
+MULTIJUICER_VERSION=${MULTIJUICER_VERSION:-7.0.1}
+# CTFd helm chart version, https://github.com/bman46/CTFd-Helm/releases
+CTFD_VERSION=${CTFD_VERSION:-v0.8.4}
+
 
 # Change locale to make "</dev/urandom tr -dc" work on Mac
 OS=`uname`
@@ -189,6 +194,7 @@ function deploy_multi_juicer() {
     # Use helm to deploy the multi-juicer chart, overriding the values (see juicer.yaml)
     helm upgrade --install multi-juicer \
         oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer \
+        --version "$MULTIJUICER_VERSION" \
         --values juicer.yaml \
         --set balancer.cookie.cookieParserSecret="$COOKIE_SECRET" \
         --set balancer.replicas="$BALANCER_REPLICAS" \
@@ -409,6 +415,7 @@ function deploy_ctfd() {
     # Use helm to deploy the CTFd chart, overriding the values (see ctfd.yaml)
     helm upgrade --install ctfd \
         oci://ghcr.io/bman46/ctfd/ctfd \
+        --version "$CTFD_VERSION" \
         --values ctfd.yaml \
         --set redis.auth.password="$CTFD_REDIS_PASS" \
         --set mariadb.auth.rootPassword="$CTFD_MYSQL_ROOT_PASS" \


### PR DESCRIPTION
Pin versions to avoid sudden breaking changes right before hosting CTF