### PR TITLE
Refactor: Make the solution cloud-agnostic

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ export AZURE_SERVICE_PRINCIPAL_NAME=""
 export AZURE_ADMIN_AAD_GROUP=""
 # Whether to create/delete the resource group. Defaults to false
 export MANAGE_RG=0
-# Whether to create/delete a container registry. Defaults to false.
-export MANAGE_ACR=0
+# Whether to create/delete the key vault. Defaults to false
+export MANAGE_KEYVAULT=0
 # Whether to create/delete the cluster itself. Defaults to false.
 export MANAGE_CLUSTER=0

--- a/.env
+++ b/.env
@@ -6,6 +6,8 @@ export COOKIE_SECRET=""
 export CTFD_SECRET_KEY=""
 
 ## Azure-specific
+# Hostname, used as <AZURE_DNS_NAME>.<LOCATION>.cloudapp.azure.com (required)
+export AZURE_DNS_NAME=""
 # The subscription ID (required)
 export AZURE_SUBSCRIPTION_ID=""
 # Name of the resource group (required)

--- a/.env
+++ b/.env
@@ -4,6 +4,8 @@ export CTF_KEY=""
 export COOKIE_SECRET=""
 # Secret for the CTFd instance (required)
 export CTFD_SECRET_KEY=""
+# FQDN (Fully Qualified Domain Name) at which the setup is accessible (required, used for TLS and routing)
+export JUICE_FQDN=""
 
 ## Azure-specific
 # Hostname, used as <AZURE_DNS_NAME>.<LOCATION>.cloudapp.azure.com (required)

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -9,10 +9,10 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - bvt-juice.norwayeast.cloudapp.azure.com
+    - $JUICE_FQDN
     secretName: juice-tls-secret
   rules:
-  - host: bvt-juice.norwayeast.cloudapp.azure.com
+  - host: $JUICE_FQDN
     http:
       paths:
         - path: /ctfd

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -7,8 +7,8 @@ SCRIPT_NAME=$(basename "$0")
 ### Required variables ###
 # Name of the resource group to use/create.
 AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:?Missing required environment variable.}"
-# Hostname, used as <DNS_NAME>.<LOCATION>.cloudapp.azure.com
-DNS_NAME="${DNS_NAME:?Missing required environment variable.}"
+# Hostname, used as <AZURE_DNS_NAME>.<LOCATION>.cloudapp.azure.com
+AZURE_DNS_NAME="${AZURE_DNS_NAME:?Missing required environment variable.}"
 
 ### Default variables ###
 ## Azure / Cluster
@@ -123,8 +123,8 @@ function configure_dns_record() {
     # Get the resource ID of the Public IP resource
     PUBLIC_IP_ID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$PUBLIC_IP')].[id]" --output tsv)
 
-    # Add the hostname <DNS_NAME> to the Public IP resource
-    az network public-ip update --ids "$PUBLIC_IP_ID" --dns-name "$DNS_NAME" 2>/dev/null || true
+    # Add the hostname <AZURE_DNS_NAME> to the Public IP resource
+    az network public-ip update --ids "$PUBLIC_IP_ID" --dns-name "$AZURE_DNS_NAME" 2>/dev/null || true
 }
 
 function destroy_dns_record() {

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -146,7 +146,7 @@ function create_keyvault() {
 
 function delete_keyvault() {
     info "Deleting the Azure Key Vault '$KEY_VAULT_NAME'"
-    az keyvault delete --location "$LOCATION" --name "$KEY_VAULT_NAME" --resource-group "$AZURE_RESOURCE_GROUP"
+    az keyvault delete --name "$KEY_VAULT_NAME" --resource-group "$AZURE_RESOURCE_GROUP"
 }
 
 function get_credentials() {

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -130,13 +130,15 @@ function configure_dns_record() {
 function destroy_dns_record() {
     info "Deleting the DNS record"
      # Get the public IP of the NGINX ingress controller
-    PUBLIC_IP=$(kubectl --namespace default get services -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' nginx-ingress-ingress-nginx-controller)
+    PUBLIC_IP=$(kubectl --namespace default get services -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' nginx-ingress-ingress-nginx-controller || true)
 
-    # Get the resource ID of the Public IP resource
-    PUBLIC_IP_ID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$PUBLIC_IP')].[id]" --output tsv)
+    if [ -n "$PUBLIC_IP" ]; then
+        # Get the resource ID of the Public IP resource
+        PUBLIC_IP_ID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$PUBLIC_IP')].[id]" --output tsv)
 
-    # Delete the public IP record
-    az network public-ip delete --ids "$PUBLIC_IP_ID"
+        # Delete the public IP record
+        az network public-ip delete --ids "$PUBLIC_IP_ID"
+    fi
 }
 
 function create_keyvault() {

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -169,7 +169,7 @@ function write_secrets_to_keyvault() {
         az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "ctfd-db-password" --value "$__CTFD_DB_PASS"
         # Push the CTFd DB root password to the key vault
         __CTFD_DB_ROOT_PASS=$(kubectl get secrets ctfd-mariadb -o=jsonpath='{.data.mariadb-root-password}' | base64 --decode)
-        az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "ctfd-db-password" --value "$__CTFD_DB_ROOT_PASS"
+        az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "ctfd-db-root-password" --value "$__CTFD_DB_ROOT_PASS"
         # Push the multi-juicer admin password to the key vault
         get_multi_juicer_admin_password
         az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "multijuicer-admin-password" --value "$MULTI_JUICER_PASS"

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -1,0 +1,257 @@
+#! /usr/bin/env bash
+# shellcheck disable=SC2015
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+
+### Required variables ###
+# Name of the resource group to use/create.
+AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:?Missing required environment variable.}"
+# Hostname, used as <DNS_NAME>.<LOCATION>.cloudapp.azure.com
+DNS_NAME="${DNS_NAME:?Missing required environment variable.}"
+
+### Default variables ###
+## Azure / Cluster
+# Region in which to deploy the services
+LOCATION="${LOCATION:-norway-east}"
+# Name to use for the cluster
+CLUSTER_NAME="${CLUSTER_NAME:-juicy-k8s}"
+# Number of nodes for the cluster
+NODE_COUNT="${NODE_COUNT:-2}"
+# Name of the key vault
+KEY_VAULT_NAME="${KEY_VAULT_NAME:-juice-shop-kv}"
+## Toggles
+# Whether to create/delete the resource group. Defaults to false
+MANAGE_RG=${MANAGE_RG:-0}
+# Whether to create/delete the cluster itself. Defaults to false, unless COMMAND is 'new' or 'wipe'
+MANAGE_CLUSTER=${MANAGE_CLUSTER:-0}
+# Whether to create/delete the key vault. Defaults to false
+MANAGE_KEYVAULT=${MANAGE_KEYVAULT:-0}
+
+function usage() {
+    echo -e "Usage: ./$SCRIPT_NAME COMMAND
+
+    Commands:
+        new\tDeploy a brand new cluster
+        down\tScale down the cluster to save resources (keeps the AKS resource itself intact)
+        up\tSpin the cluster back up, scaling up the resources
+        wipe\tWipe it, deleting all services including the cluster and key vault
+        dns\tConfigure the DNS record for the NGINX controller deployed by 'manage-multijuicer.sh'
+        password\tRetrieve the admin password for the MultiJuicer instance
+    "
+    exit 0
+}
+
+function setup_colors() {
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+  else
+    # shellcheck disable=SC2034
+    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+  fi
+}
+
+setup_colors
+
+info() {
+  echo >&2 -e "${CYAN}$1${NOFORMAT}"
+}
+
+success() {
+  echo >&2 -e "${GREEN}    SUCCESS${NOFORMAT}"
+}
+
+failure() {
+  echo >&2 -e "${RED}${1:-\tERROR}${NOFORMAT}"
+}
+
+ARGS=("$@")
+[[ ${#ARGS[@]} -eq 0 ]] && usage
+
+# Command to execute
+COMMAND="${ARGS[0]}"
+
+function create_resource_group() {
+    info "Creating Resource Group '$AZURE_RESOURCE_GROUP' in '$LOCATION'"
+    # Create a new resource group
+    az group create --location "$LOCATION" --name "$AZURE_RESOURCE_GROUP"
+}
+
+function destroy_resource_group() {
+    info "Deleting Resource Group '$AZURE_RESOURCE_GROUP'" 
+    # Delete the resource group
+    az group delete --yes --name "$AZURE_RESOURCE_GROUP"
+}
+
+function create_cluster() {
+    info "Creating AKS cluster '$CLUSTER_NAME'"
+    # Create the AKS cluster
+    az aks create --yes --resource-group "$AZURE_RESOURCE_GROUP" --name "$CLUSTER_NAME" --node-count "$NODE_COUNT" --no-ssh-key
+}
+
+function destroy_cluster() {
+    info "Deleting AKS cluster '$CLUSTER_NAME'"
+    # Delete the AKS cluster
+    az aks delete --yes --resource-group "$AZURE_RESOURCE_GROUP" --name "$CLUSTER_NAME"
+}
+
+function start_vm_scale_set() {
+    info "Starting the VM scale set"
+    # Get the name of the node resource group
+    NODE_RESOURCE_GROUP=$(az aks list --query "[].nodeResourceGroup" --output tsv)
+    # Get the name of the VM scale set
+    SCALE_SET_NAME=$(az vmss list --resource-group "$NODE_RESOURCE_GROUP" --query "[].name" --output tsv)
+    # Start the VM scale set
+    az vmss start --resource-group "$NODE_RESOURCE_GROUP" --name "$SCALE_SET_NAME"
+}
+
+function deallocate_vm_scale_set() {
+    info "Deallocating the VM scale set"
+    # Get the name of the node resource group
+    NODE_RESOURCE_GROUP=$(az aks list --query "[].nodeResourceGroup" --output tsv)
+    # Get the name of the VM scale set
+    SCALE_SET_NAME=$(az vmss list --resource-group "$NODE_RESOURCE_GROUP" --query "[].name" --output tsv)
+    # Start the VM scale set
+    az vmss deallocate --resource-group "$NODE_RESOURCE_GROUP" --name "$SCALE_SET_NAME"
+}
+
+function configure_dns_record() {
+    info "Configuring the DNS record"
+    # Get the public IP of the NGINX ingress controller
+    PUBLIC_IP=$(kubectl --namespace default get services -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' nginx-ingress-ingress-nginx-controller)
+
+    # Get the resource ID of the Public IP resource
+    PUBLIC_IP_ID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$PUBLIC_IP')].[id]" --output tsv)
+
+    # Add the hostname <DNS_NAME> to the Public IP resource
+    az network public-ip update --ids "$PUBLIC_IP_ID" --dns-name "$DNS_NAME" 2>/dev/null || true
+}
+
+function destroy_dns_record() {
+    info "Deleting the DNS record"
+     # Get the public IP of the NGINX ingress controller
+    PUBLIC_IP=$(kubectl --namespace default get services -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' nginx-ingress-ingress-nginx-controller)
+
+    # Get the resource ID of the Public IP resource
+    PUBLIC_IP_ID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$PUBLIC_IP')].[id]" --output tsv)
+
+    # Delete the public IP record
+    az network public-ip delete --ids "$PUBLIC_IP_ID"
+}
+
+function create_keyvault() {
+    info "Creating the Azure Key Vault '$KEY_VAULT_NAME'"
+    az keyvault create --location "$LOCATION" --name "$KEY_VAULT_NAME" --resource-group "$AZURE_RESOURCE_GROUP"
+}
+
+function delete_keyvault() {
+    info "Deleting the Azure Key Vault '$KEY_VAULT_NAME'"
+    az keyvault delete --location "$LOCATION" --name "$KEY_VAULT_NAME" --resource-group "$AZURE_RESOURCE_GROUP"
+}
+
+function get_credentials() {
+    # Retrieve the credentials for the cluster
+    az aks get-credentials --resource-group "$AZURE_RESOURCE_GROUP" --name "$CLUSTER_NAME" --overwrite-existing
+}
+
+function get_multi_juicer_admin_password() {
+    # Get the multi-juicer admin password
+    MULTI_JUICER_PASS=$(kubectl get secrets juice-balancer-secret -o=jsonpath='{.data.adminPassword}' | base64 --decode)
+    if [ -z "$MULTI_JUICER_PASS" ]; then
+        failure "Failed to retrieve the multi-juicer admin password"
+        exit 1
+    fi
+    if [ "$MANAGE_KEYVAULT" -eq 1 ]; then
+        # Push the password to the key vault
+        az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "multijuicer-admin-password" --value "$MULTI_JUICER_PASS"
+    else
+        info "Admin password:\n$MULTI_JUICER_PASS"
+    fi
+}
+
+function up() {
+    info "Deploying the Kubernetes cluster"
+    # Manage the resource group
+    if [ "$MANAGE_RG" -eq 1 ]; then
+        create_resource_group && success
+    fi
+    # Manage the cluster itself
+    if [ "$MANAGE_CLUSTER" -eq 1 ]; then
+        create_cluster && success
+    fi
+    if [ "$MANAGE_CLUSTER" -eq 0 ]; then
+        start_vm_scale_set && success
+    fi
+    if [ "$MANAGE_KEYVAULT" -eq 1 ]; then
+        create_keyvault && success
+    fi
+    get_credentials
+    info "DONE"
+}
+
+function down() {
+    info "Shutting down the Kubernetes cluster"
+    # Manage the resource group
+    if [ "$MANAGE_RG" -eq 1 ]; then
+        destroy_resource_group && success || failure
+    fi
+    get_credentials 2> /dev/null || true
+    # Manage the cluster itself
+    if [ "$MANAGE_CLUSTER" -eq 1 ]; then
+        destroy_cluster && success || failure
+    fi
+    if [ "$MANAGE_CLUSTER" -eq 0 ]; then
+        deallocate_vm_scale_set && success || failure
+    fi
+    if [ "$MANAGE_KEYVAULT" -eq 1 ]; then
+        delete_keyvault && success
+    fi
+    info "DONE"
+}
+
+function configure_dns() {
+    info "Configuring the DNS record"
+    get_credentials
+    configure_dns_record && success
+    info "DONE"
+}
+
+function get_admin_password() {
+    info "Retrieving the admin password for the multi-juicer instance"
+    get_credentials
+    get_multi_juicer_admin_password
+    info "DONE"
+}
+
+case "$COMMAND" in
+    "-h" | "--help")
+        usage
+        ;;
+    "new")
+        MANAGE_CLUSTER=1
+        up
+        ;;
+    "up")
+        MANAGE_CLUSTER=0
+        up
+        ;;
+    "down")
+        MANAGE_CLUSTER=0
+        down
+        ;;
+    "wipe")
+        MANAGE_CLUSTER=1
+        MANAGE_KEYVAULT=1
+        down
+        ;;
+    "dns")
+        configure_dns
+        ;;
+    "password")
+        get_admin_password
+        ;;
+    *)
+        failure "Invalid argument '$COMMAND'\n"
+        usage
+        ;;
+esac

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -151,7 +151,7 @@ function delete_keyvault() {
     az keyvault delete --name "$KEY_VAULT_NAME" --resource-group "$AZURE_RESOURCE_GROUP"
 }
 
-function get_credentials() {
+function get_cluster_credentials() {
     # Retrieve the credentials for the cluster
     az aks get-credentials --resource-group "$AZURE_RESOURCE_GROUP" --name "$CLUSTER_NAME" --overwrite-existing
 }
@@ -187,7 +187,7 @@ function up() {
     if [ "$MANAGE_KEYVAULT" -eq 1 ]; then
         create_keyvault && success
     fi
-    get_credentials
+    get_cluster_credentials
     info "DONE"
 }
 
@@ -197,7 +197,7 @@ function down() {
     if [ "$MANAGE_RG" -eq 1 ]; then
         destroy_resource_group && success || failure
     fi
-    get_credentials 2> /dev/null || true
+    get_cluster_credentials 2> /dev/null || true
     # Manage the cluster itself
     if [ "$MANAGE_CLUSTER" -eq 1 ]; then
         destroy_cluster && success || failure
@@ -213,14 +213,14 @@ function down() {
 
 function configure_dns() {
     info "Configuring the DNS record"
-    get_credentials
+    get_cluster_credentials
     configure_dns_record && success
     info "DONE"
 }
 
 function get_admin_password() {
     info "Retrieving the admin password for the multi-juicer instance"
-    get_credentials
+    get_cluster_credentials
     get_multi_juicer_admin_password
     info "DONE"
 }

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -198,6 +198,7 @@ function down() {
         destroy_resource_group && success || failure
     fi
     get_cluster_credentials 2> /dev/null || true
+    destroy_dns_record
     # Manage the cluster itself
     if [ "$MANAGE_CLUSTER" -eq 1 ]; then
         destroy_cluster && success || failure

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -11,6 +11,8 @@ CTF_KEY="${CTF_KEY:?Missing required environment variable.}"
 COOKIE_SECRET="${COOKIE_SECRET:?Missing required environment variable.}"
 # Secret for the CTFd instance
 CTFD_SECRET_KEY="${CTFD_SECRET_KEY:?Missing required environment variable.}"
+# FQDN (Fully Qualified Domain Name) at which the setup is accessible (used for TLS)
+JUICE_FQDN="${JUICE_FQDN:?Missing required environment variable.}"
 
 ### Default variables ###
 ## MultiJuicer / JuiceShop
@@ -231,7 +233,7 @@ function apply_cluster_issuer() {
 
 function apply_ingress() {
     info "Configuring ingress"
-    kubectl apply -f ingress.yaml --namespace default
+    < ingress.yaml envsubst | kubectl apply --namespace default -f -
 }
 
 function deploy_monitoring() {

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -37,6 +37,19 @@ if [ "$OS" = 'Darwin' ]; then
     export LC_CTYPE=C
 fi
 
+__REQUIRED_BINARIES=(
+    "helm"
+    "kubectl"
+    "envsubst"
+)
+# Check that all required binaries are present
+for __REQ_PKG in "${__REQUIRED_BINARIES[@]}"; do
+    if ! which "$__REQ_PKG" &> /dev/null ; then
+        echo "ERROR: Missing required package '$__REQ_PKG'"
+        exit 1
+    fi
+done
+
 # Whether to delete PVCs (Persistent Volume Claims) when running 'down'
 # If no MYSQL/Redis password is supplied, it will be random-generated, and as such will result in failure when running 'up',
 # as a new password will be generated which does not match the persisted database password.

--- a/service-principal.sh
+++ b/service-principal.sh
@@ -5,13 +5,13 @@ SCRIPT_NAME=$(basename "$0")
 
 ### Required variables ###
 # The subscription ID (required)
-export AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:?Missing required environment variable.}"
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:?Missing required environment variable.}"
 # Name of the resource group (required)
-export AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:?Missing required environment variable.}"
+AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:?Missing required environment variable.}"
 # Name of the service principal (required)
-export AZURE_SERVICE_PRINCIPAL_NAME="${AZURE_SERVICE_PRINCIPAL_NAME:?Missing required environment variable.}"
+AZURE_SERVICE_PRINCIPAL_NAME="${AZURE_SERVICE_PRINCIPAL_NAME:?Missing required environment variable.}"
 # Name of the admin Azure AD group
-export AZURE_ADMIN_AAD_GROUP="${AZURE_ADMIN_AAD_GROUP:?Missing required environment variable.}"
+AZURE_ADMIN_AAD_GROUP="${AZURE_ADMIN_AAD_GROUP:?Missing required environment variable.}"
 
 function usage() {
     echo -e "Usage: ./$SCRIPT_NAME COMMAND


### PR DESCRIPTION
Ensures that the main script, `manage-multijuicer.sh`, can be used with any k8s provider (Azure, AWS, ...), by splitting the Azure-specific logic to a separate file.

Must be merged **prior** to #49 and #50 