### PR TITLE
CI: workflow for deploying via actions

### DIFF
--- a/.github/workflows/azure-login.yaml
+++ b/.github/workflows/azure-login.yaml
@@ -14,7 +14,7 @@ permissions:
       contents: read
 
 jobs:
-  build-and-deploy:
+  log-in:
     runs-on: ubuntu-latest
     steps:
       - name: 'Az CLI login'
@@ -23,8 +23,3 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: 'Run az commands'
-        run: |
-          az account show
-          az group list

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -1,0 +1,49 @@
+name: Deploy CTF services on Azure Kubernetes Service
+on:
+  workflow_dispatch:
+    inputs:
+      ENVIRONMENT:
+        default: ctf
+        description: The name of the GitHub environment to use (https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#about-environments)
+        type: environment
+      
+permissions:
+      id-token: write # Required for requesting the JWT
+      contents: read
+
+jobs:
+  deploy:
+    name: Deploy CTF services
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.ENVIRONMENT }}
+    steps:
+      - name: Run az login
+        uses: ./.github/workflows/azure-login.yaml
+
+      - name: Create the Kubernetes cluster in AKS
+        run: |
+          ./manage-azure-deployment.sh new
+
+      - name: Deploy the CTF services
+        run: |
+          ./manage-multijuicer.sh up
+
+      - name: Run post-deployment configuration tasks
+        run: |
+          ./manage-azure-deployment.sh config 
+
+  import-challenges:
+    name: Import challenges to CTFd
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.ENVIRONMENT }}
+    steps:
+      - name: Generate challenges
+        run: |
+          ./generate-challenges.sh
+
+      - name: Upload CTFd challenges file as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctfd-challenges.csv
+          path: ctfd-challenges-*.csv
+          retention-days: 7


### PR DESCRIPTION
## Why is this pull request needed?

To allow deploying CTF services via GitHub Actions workflows.

## What does this pull request change?

Adds a new workflow which handles the deployment of the CTF services to AKS

## Issues related to this change:
