### PR TITLE
CI: Add support for deployment via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -93,10 +93,6 @@ jobs:
         run: |
           ./manage-multijuicer.sh up
 
-      - name: Run post-deployment configuration tasks
-        run: |
-          ./manage-azure-deployment.sh config 
-
   import-challenges:
     name: Import challenges to CTFd
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -24,6 +24,25 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.1'
+
+      - name: Install helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.14.0'
+
+      - name: Install go
+        uses: actions/setup-go@v5
+      
+      - name: Install envsubst
+        run: |
+          go install github.com/a8m/envsubst/cmd/envsubst@v1.4.2
 
       - name: Create the Kubernetes cluster in AKS
         run: |
@@ -42,6 +61,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT }}
     steps:
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.1'
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install juice-shop-ctf-cli
+        run: npm install -g juice-shop-ctf-cli
+
       - name: Generate challenges
         run: |
           ./generate-challenges.sh

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -103,6 +103,9 @@ jobs:
     environment: ${{ inputs.ENVIRONMENT }}
     needs: [deploy]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Install kubectl
         uses: azure/setup-kubectl@v3
         with:

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -6,7 +6,20 @@ on:
         default: ctf
         description: The name of the GitHub environment to use (https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#about-environments)
         type: environment
-      
+  workflow_call:
+    inputs:
+      ENVIRONMENT:
+        default: ctf
+        description: The name of the GitHub environment to use (https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#about-environments)
+        type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
 permissions:
       id-token: write # Required for requesting the JWT
       contents: read

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -18,7 +18,12 @@ jobs:
     environment: ${{ inputs.ENVIRONMENT }}
     steps:
       - name: Run az login
-        uses: ./.github/workflows/azure-login.yaml
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
 
       - name: Create the Kubernetes cluster in AKS
         run: |

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -93,37 +93,37 @@ jobs:
         run: |
           ./manage-multijuicer.sh up
 
-  import-challenges:
-    name: Import challenges to CTFd
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.ENVIRONMENT }}
-    needs: [deploy]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  # import-challenges:
+  #   name: Import challenges to CTFd
+  #   runs-on: ubuntu-latest
+  #   environment: ${{ inputs.ENVIRONMENT }}
+  #   needs: [deploy]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v3
-        with:
-          version: 'v1.29.1'
+  #     - name: Install kubectl
+  #       uses: azure/setup-kubectl@v3
+  #       with:
+  #         version: 'v1.29.1'
 
-      - name: Install node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+  #     - name: Install node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
 
-      - name: Install juice-shop-ctf-cli
-        run: npm install -g juice-shop-ctf-cli
+  #     - name: Install juice-shop-ctf-cli
+  #       run: npm install -g juice-shop-ctf-cli
 
-      - name: Generate challenges
-        env:
-          CTF_KEY: ${{ secrets.CTF_KEY }}
-        run: |
-          ./generate-challenges.sh
+  #     - name: Generate challenges
+  #       env:
+  #         CTF_KEY: ${{ secrets.CTF_KEY }}
+  #       run: |
+  #         ./generate-challenges.sh
 
-      - name: Upload CTFd challenges file as an artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ctfd-challenges.csv
-          path: ctfd-challenges-*.csv
-          retention-days: 7
+  #     - name: Upload CTFd challenges file as an artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ctfd-challenges.csv
+  #         path: ctfd-challenges-*.csv
+  #         retention-days: 7

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -33,9 +33,9 @@ jobs:
       - name: Run az login
         uses: azure/login@v1
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -60,6 +60,7 @@ jobs:
     name: Import challenges to CTFd
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT }}
+    needs: [deploy]
     steps:
       - name: Install kubectl
         uses: azure/setup-kubectl@v3
@@ -70,7 +71,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
 
       - name: Install juice-shop-ctf-cli
         run: npm install -g juice-shop-ctf-cli

--- a/.github/workflows/deploy-ctf.yaml
+++ b/.github/workflows/deploy-ctf.yaml
@@ -29,6 +29,18 @@ jobs:
     name: Deploy CTF services
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT }}
+    env:
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_DNS_NAME: ${{ vars.AZURE_DNS_NAME }}
+      AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+      CLUSTER_NAME: ${{ vars.CLUSTER_NAME }}
+      NODE_COUNT: ${{ vars.NODE_COUNT }}
+      KEY_VAULT_NAME: ${{ vars.KEY_VAULT_NAME }}
+      MANAGE_RG: ${{ vars.MANAGE_RG }}
+      PURGE_RG: ${{ vars.PURGE_RG }}
+      MANAGE_CLUSTER: ${{ vars.MANAGE_CLUSTER }}
+      MANAGE_KEYVAULT: ${{ vars.MANAGE_KEYVAULT }}
+      PURGE_KEYVAULT: ${{ vars.PURGE_KEYVAULT }}
     steps:
       - name: Run az login
         uses: azure/login@v1
@@ -62,6 +74,22 @@ jobs:
           ./manage-azure-deployment.sh new
 
       - name: Deploy the CTF services
+        env:
+          CTF_KEY: ${{ secrets.CTF_KEY }}
+          COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
+          CTFD_SECRET_KEY: ${{ secrets.CTFD_SECRET_KEY }}
+          JUICE_FQDN: ${{ vars.JUICE_FQDN }}
+          BALANCER_REPLICAS: ${{ vars.BALANCER_REPLICAS }}
+          MAX_INSTANCES: ${{ vars.MAX_INSTANCES }}
+          GRACE_PERIOD: ${{ vars.GRACE_PERIOD }}
+          MANAGE_MONITORING: ${{ vars.MANAGE_MONITORING }}
+          MANAGE_CTFD: ${{ vars.MANAGE_CTFD }}
+          METRICS_PASS: ${{ secrets.METRICS_PASS }}
+          GRAFANA_PASS: ${{ secrets.GRAFANA_PASS }}
+          CTFD_REDIS_PASS: ${{ secrets.CTFD_REDIS_PASS }}
+          CTFD_MYSQL_ROOT_PASS: ${{ secrets.CTFD_MYSQL_ROOT_PASS }}
+          CTFD_MYSQL_PASS: ${{ secrets.CTFD_MYSQL_PASS }}
+          CTFD_MYSQL_REPL_PASS: ${{ secrets.CTFD_MYSQL_REPL_PASS }}
         run: |
           ./manage-multijuicer.sh up
 
@@ -89,6 +117,8 @@ jobs:
         run: npm install -g juice-shop-ctf-cli
 
       - name: Generate challenges
+        env:
+          CTF_KEY: ${{ secrets.CTF_KEY }}
         run: |
           ./generate-challenges.sh
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Usage: ./manage-azure-deployment.sh COMMAND
         down    Scale down the cluster to save resources (keeps the AKS resource itself intact)
         wipe    Removes the cluster
         wipe-all        Removes the cluster, resource group, and key vault.
-        config  Run post-deployment configurations, including creating the DNS record in Azure
+        write-secrets   Write the secrest to Azure Key Vault.
         password        Retrieve the admin password for the multi-juicer instance
 
 ```
@@ -134,8 +134,8 @@ Usage: ./manage-azure-deployment.sh COMMAND
 # Shut down the cluster and remove the AKS resource as well as the resource group and key vault.
 ./manage-azure-deployment.sh wipe-all
 
-# Run post-deployment configurations. Must be run after running `manage-multijuicer.sh up` to configure the DNS record and more.
-./manage-azure-deployment.sh config
+# Write the secrets to the Azure Keyvault
+./manage-azure-deployment.sh write-secrets
 
 # Retrieve the password for the admin-user in the MultiJuicer instance
 ./manage-azure-deployment.sh password
@@ -149,9 +149,6 @@ You may use the domain name provided by Azure DNS to reach your host. If you wis
 
 # Next, we will deploy the services in the Kubernetes cluster
 ./manage-multijuicer.sh up
-
-# Run the post-deployment configuration to finalize the deployment
-./manage-azure-deployment.sh config
 
 # Next, generate the challenge list for CTFd and upload the CSV file to CTFd
 ./generate-challenges.sh

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -162,6 +162,8 @@ function __kv_exists() {
 }
 
 function write_secrets_to_keyvault() {
+    # Activate the namespace in which multi-juicer resources are deployed
+    ./manage-multijuicer.sh set-namespace
     info "Writing secrets to the Azure Key Vault '$KEY_VAULT_NAME'"
     if __kv_exists; then
         # Push the CTFd DB password to the key vault
@@ -178,6 +180,8 @@ function write_secrets_to_keyvault() {
 }
 
 function get_multi_juicer_admin_password() {
+    # Activate the namespace in which multi-juicer resources are deployed
+    ./manage-multijuicer.sh set-namespace
     # Get the multi-juicer admin password
     MULTI_JUICER_PASS=$(kubectl get secrets juice-balancer-secret -o=jsonpath='{.data.adminPassword}' | base64 --decode)
     if [ -z "$MULTI_JUICER_PASS" ]; then

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -53,7 +53,7 @@ function usage() {
         down\tScale down the cluster to save resources (keeps the AKS resource itself intact)
         wipe\tRemoves the cluster
         wipe-all\tRemoves the cluster, resource group, and key vault.
-        config\tRun post-deployment configurations, including creating the DNS record in Azure
+        write-secrets\tWrite the secrest to Azure Key Vault.
         password\tRetrieve the admin password for the multi-juicer instance
     "
     exit 0
@@ -234,13 +234,6 @@ function down() {
     info "DONE"
 }
 
-function post_configuration() {
-    info "Running post-deployment configuration tasks"
-    get_cluster_credentials
-    write_secrets_to_keyvault && success
-    info "DONE"
-}
-
 function get_admin_password() {
     info "Retrieving the admin password for the multi-juicer instance"
     get_cluster_credentials
@@ -275,8 +268,8 @@ case "$COMMAND" in
         MANAGE_KEYVAULT=1
         down
         ;;
-    "config" | "cfg")
-        post_configuration
+    "write-secrets")
+        write_secrets_to_keyvault && success
         ;;
     "password")
         get_admin_password

--- a/manage-azure-deployment.sh
+++ b/manage-azure-deployment.sh
@@ -21,8 +21,10 @@ NODE_COUNT="${NODE_COUNT:-2}"
 # Name of the key vault
 KEY_VAULT_NAME="${KEY_VAULT_NAME:-juice-shop-kv}"
 ## Toggles
-# Whether to create/delete the resource group. Defaults to false
+# Whether to create the resource group. Defaults to false
 MANAGE_RG=${MANAGE_RG:-0}
+# Whether to purge the resource group. Defaults to false.
+PURGE_RG=${PURGE_RG:-0}
 # Whether to create/delete the cluster itself. Defaults to false, unless COMMAND is 'new' or 'wipe'
 MANAGE_CLUSTER=${MANAGE_CLUSTER:-0}
 # Whether to create/delete the key vault. Defaults to false
@@ -131,7 +133,7 @@ function deallocate_vm_scale_set() {
     NODE_RESOURCE_GROUP=$(az aks list --query "[].nodeResourceGroup" --output tsv)
     # Get the name of the VM scale set
     SCALE_SET_NAME=$(az vmss list --resource-group "$NODE_RESOURCE_GROUP" --query "[].name" --output tsv)
-    # Start the VM scale set
+    # Stop the VM scale set
     az vmss deallocate --resource-group "$NODE_RESOURCE_GROUP" --name "$SCALE_SET_NAME"
 }
 
@@ -211,8 +213,8 @@ function up() {
 
 function down() {
     info "Shutting down the services"
-    # Manage the resource group
-    if [ "$MANAGE_RG" -eq 1 ]; then
+    # Remove the resource group
+    if [ "$PURGE_RG" -eq 1 ]; then
         destroy_resource_group && success || failure
     fi
     get_cluster_credentials 2> /dev/null || true

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -196,6 +196,7 @@ function deploy_ingress() {
         --set controller.image.digest="" \
         --set controller.admissionWebhooks.patch.nodeSelector."kubernetes\.io/os"=linux \
         --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
+        --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-dns-label-name"="${AZURE_DNS_NAME:-''}" \
         --set controller.admissionWebhooks.patch.image.registry="$K8S_CONTAINER_REGISTRY" \
         --set controller.admissionWebhooks.patch.image.image="$PATCH_IMAGE" \
         --set controller.admissionWebhooks.patch.image.tag="$PATCH_TAG" \

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -316,7 +316,7 @@ function destroy_monitoring() {
     kubectl delete crd thanosrulers.monitoring.coreos.com
     
     # Delete the namespace for the monitoring services
-    kubectl delete namespace "$__MONITORING_NAMESPACE" --force
+    kubectl delete namespace "$__MONITORING_NAMESPACE"
 
     # Set the monitoring namespace as the current context
     set_active_namespace "$__CTF_NAMESPACE"
@@ -387,7 +387,7 @@ function down() {
     fi
     destroy_multi_juicer && success || failure
     # Delete the namespace for the CTF services
-    kubectl delete namespace "$__CTF_NAMESPACE" --force
+    kubectl delete namespace "$__CTF_NAMESPACE"
     # Manage the monitoring services (prometheus/grafana/loki)
     if [ "$MANAGE_MONITORING" -eq 1 ]; then
         destroy_monitoring && success || failure

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -106,7 +106,7 @@ failure() {
 }
 
 function randstr() {
-    </dev/urandom tr -dc 'A-Za-z0-9' | head -c 24; echo
+    dd bs=512 if=/dev/urandom count=1 2>/dev/null | LC_ALL=C tr -dc "a-zA-Z0-9" | head -c 24; echo
 }
 
 ARGS=("$@")

--- a/manage-multijuicer.sh
+++ b/manage-multijuicer.sh
@@ -405,6 +405,9 @@ case "$COMMAND" in
     "down")
         down
         ;;
+    "set-ns" | "set-namespace")
+        set_active_namespace
+        ;;
     *)
         failure "Invalid argument '$COMMAND'\n"
         usage


### PR DESCRIPTION
## Why is this pull request needed?

This pull request adds support for deploying the CTF services via GitHub Actions.

## What does this pull request change?

- Changes the reusable workflow from a step in a job, to a separate job.
- Ensures that the required dependencies are installed
- Adds support for workflow_call (makes the action reusable)
- Passes all necessary variables to the jobs/steps
- Azure DNS record creation is now performed by `helm apply`, rather than by manual `az` commands
  - to resolve permission issues with the service principal lacking permissions on the `aks` cluster's sub-resources, which are created in separate resource groups
  - and to allow instant DNS record creation (rather than having to run the `config` command from `manage-azure-deployment.sh`, which leads to a delay, which causes the TLS certificate acquisition to be delayed)
- Skips deleting the resource group in Azure, unless `PURGE_RG` is true, since custom roles in Azure depend on the ID of the resource group for their scope.

### Fixes
- Removed the `--force` flag when deleting namespaces (which caused the occasional hang-up of the delete command)

## Issues related to this change:
- Relates to #11 